### PR TITLE
Fix `opt_einsum` paths for dt_equations

### DIFF
--- a/tests/deep/files/test_code_dt_equations/code_output_dt_amplitude_equations.py
+++ b/tests/deep/files/test_code_dt_equations/code_output_dt_amplitude_equations.py
@@ -130,14 +130,14 @@ def solve_doubles_equations(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_arg
 
 # ---------------------------- DISCONNECTED TERMS ---------------------------- #
 
-def _order_1_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list):
+def _order_1_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_linked_path_list):
     """Exists for error checking."""
     raise Exception(
         "the first possible purely VECI/CC term is (1, 1) or (dt_i * t_i)"
         "which requires a residual of at least 2nd order"
     )
 
-def _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list):
+def _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_linked_path_list):
     """Calculate all uniquely linked disconnected terms generated from the wave operator ansatz.
     This means for order 5 we include terms such as (4, 1), (3, 1, 1), (2, 1, 1, 1)
     But not terms (5), (3, 2), (2, 2, 1), (1, 1, 1, 1, 1)
@@ -146,8 +146,8 @@ def _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, o
     # unpack the `t_args` and 'dt_args'
     t_i, *unusedargs = t_args
     dt_i, *unusedargs = dt_args
-    # make an iterable out of the `opt_path_list`
-    optimized_einsum = iter(opt_path_list)
+    # make an iterable out of the `opt_linked_path_list`
+    optimized_einsum = iter(opt_linked_path_list)
     # Creating the 2nd order return array
     linked_disconnected_terms = np.zeros((A, A, N, N), dtype=complex)
     # the (1, 1) term
@@ -158,14 +158,14 @@ def _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, o
 
     return linked_disconnected_terms
 
-def _order_1_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list):
+def _order_1_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_unlinked_path_list):
     """Exists for error checking."""
     raise Exception(
         "the first possible purely VECC term is (2, 2) or (dt_ij * t_ij)"
         "which requires a residual of at least 4th order"
     )
 
-def _order_2_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list):
+def _order_2_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_unlinked_path_list):
     """Exists for error checking."""
     raise Exception(
         "the first possible purely VECC term is (2, 2) or (dt_ij * t_ij)"
@@ -174,7 +174,7 @@ def _order_2_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args
 
 # ---------------------------- dt AMPLITUDES ---------------------------- #
 
-def _calculate_order_1_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_epsilon, opt_path_list):
+def _calculate_order_1_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_epsilon, opt_linked_path_list, opt_unlinked_path_list):
     """Calculate the derivative of the 1 t-amplitude for use in the calculation of the residuals.
     Uses optimized summation paths generate using `contract_expression` from the `opt_einsum` library.
     """
@@ -197,14 +197,12 @@ def _calculate_order_1_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_ar
     dt_i = symmetrize_tensor(N, residual, order=1)
     return dt_i
 
-def _calculate_order_2_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_epsilon, opt_path_list):
+def _calculate_order_2_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_epsilon, opt_linked_path_list, opt_unlinked_path_list):
     """Calculate the derivative of the 2 t-amplitude for use in the calculation of the residuals.
     Uses optimized summation paths generate using `contract_expression` from the `opt_einsum` library.
     """
     # unpack the `w_args`
     w_i, w_ij, *unusedargs = w_args
-    # make an iterable out of the `opt_path_list`
-    optimized_einsum = iter(opt_path_list)
     # Calculate the 2nd order residual
     residual = residual_equations.calculate_order_2_residual(A, N, trunc, h_args, w_args)
     # subtract the epsilon term (which is R_0)
@@ -214,9 +212,9 @@ def _calculate_order_2_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_ar
     if ansatz.VECI:
         pass  # veci does not include any disconnected terms
     elif ansatz.VE_MIXED:
-        residual -= _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list)
+        residual -= _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_linked_path_list)
     elif ansatz.VECC:
-        residual -= _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list)
+        residual -= _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_linked_path_list)
         pass  # no un-linked disconnected terms for order < 4
 
     # Symmetrize the residual operator
@@ -233,7 +231,14 @@ def solve_singles_equations_optimized(A, N, ansatz, trunc, epsilon, h_args, t_ar
             "It appears that singles is not true, this cannot be."
             "Something went terribly wrong!!!"
         )
-    dt_i = _calculate_order_1_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_path_list)
+
+    # unpack the opt_einsum path's
+    opt_epsilon_path_list, opt_linked_path_list, opt_unlinked_path_list = opt_path_list
+
+    dt_i = _calculate_order_1_dt_amplitude_optimized(
+        A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args,
+        opt_epsilon_path_list[0], opt_linked_path_list[0], opt_unlinked_path_list[0]
+    )
     return dt_i
 
 def solve_doubles_equations_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_path_list):
@@ -244,16 +249,68 @@ def solve_doubles_equations_optimized(A, N, ansatz, trunc, epsilon, h_args, t_ar
             "It appears that doubles is not true, this cannot be."
             "Something went terribly wrong!!!"
         )
-    dt_ij = _calculate_order_2_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_path_list)
+
+    # unpack the opt_einsum path's
+    opt_epsilon_path_list, opt_linked_path_list, opt_unlinked_path_list = opt_path_list
+
+    dt_ij = _calculate_order_2_dt_amplitude_optimized(
+        A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args,
+        opt_epsilon_path_list[1], opt_linked_path_list[1], opt_unlinked_path_list[1]
+    )
     return dt_ij
 
 # ---------------------------- OPTIMIZED PATHS FUNCTION ---------------------------- #
 
 def compute_optimized_paths(A, N, truncation):
-    """Calculate optimized paths for the einsum calls up to `highest_order`."""
+    """Calculate all optimized paths for the `opt_einsum` calls."""
+
+    epsilon_opt_paths = compute_optimized_epsilon_paths(A, N, truncation)
+    linked_opt_paths = compute_optimized_linked_paths(A, N, truncation)
+    unlinked_opt_paths = compute_optimized_unlinked_paths(A, N, truncation)
+
+    all_opt_paths = [epsilon_opt_paths, linked_opt_paths, unlinked_opt_paths]
+
+    return all_opt_paths
+
+
+def compute_optimized_epsilon_paths(A, N, truncation):
+    """Calculate optimized paths for the constant/epsilon einsum calls up to `highest_order`."""
+
+    epsilon_path_list = []
+
+    if truncation.singles:
+        epsilon_path_list.append(oe.contract_expression('aci,cb->abi', (A, A, N), (A, A)))
+
+    if truncation.doubles:
+        epsilon_path_list.append(oe.contract_expression('acij,cb->abij', (A, A, N, N), (A, A)))
+
+    return epsilon_path_list
+
+
+def compute_optimized_linked_paths(A, N, truncation):
+    """Calculate optimized paths for the linked-disconnected einsum calls up to `highest_order`."""
 
     order_1_list, order_2_list, order_3_list = [], [], []
     order_4_list, order_5_list, order_6_list = [], [], []
 
-    return [None]
+    if truncation.singles:
+        order_2_list.extend([
+            oe.contract_expression('aci, cbj->abij', (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cbj->abij', (A, A, N), (A, A, N)),
+        ])
+
+    return [order_1_list, order_2_list]
+
+
+def compute_optimized_unlinked_paths(A, N, truncation):
+    """Calculate optimized paths for the unlinked-disconnected einsum calls up to `highest_order`."""
+
+    order_1_list, order_2_list, order_3_list = [], [], []
+    order_4_list, order_5_list, order_6_list = [], [], []
+
+    if not truncation.doubles:
+        log.warning('Did not calculate optimized unlinked paths of the dt amplitudes')
+        return [[], [], [], [], [], []]
+
+    return [order_1_list, order_2_list, order_3_list]
 

--- a/tests/deep/files/test_code_dt_equations/construct_dt_amplitude_definition_einsum_out.py
+++ b/tests/deep/files/test_code_dt_equations/construct_dt_amplitude_definition_einsum_out.py
@@ -1,9 +1,7 @@
 
-def _calculate_order_3_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_epsilon, opt_path_list):
+def _calculate_order_3_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_epsilon, opt_linked_path_list, opt_unlinked_path_list):
     """Calculate the derivative of the 3 t-amplitude for use in the calculation of the residuals.
     Uses optimized summation paths generate using `contract_expression` from the `opt_einsum` library.
     """
     # unpack the `w_args`
     w_i, w_ij, w_ijk, *unusedargs = w_args
-    # make an iterable out of the `opt_path_list`
-    optimized_einsum = iter(opt_path_list)

--- a/tests/deep/files/test_code_dt_equations/construct_linked_disconnected_definition_einsum_out.py
+++ b/tests/deep/files/test_code_dt_equations/construct_linked_disconnected_definition_einsum_out.py
@@ -1,5 +1,5 @@
 
-def _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list):
+def _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_linked_path_list):
     """Calculate all uniquely linked disconnected terms generated from the wave operator ansatz.
     This means for order 5 we include terms such as (4, 1), (3, 1, 1), (2, 1, 1, 1)
     But not terms (5), (3, 2), (2, 2, 1), (1, 1, 1, 1, 1)
@@ -8,5 +8,5 @@ def _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, o
     # unpack the `t_args` and 'dt_args'
     t_i, *unusedargs = t_args
     dt_i, *unusedargs = dt_args
-    # make an iterable out of the `opt_path_list`
-    optimized_einsum = iter(opt_path_list)
+    # make an iterable out of the `opt_linked_path_list`
+    optimized_einsum = iter(opt_linked_path_list)

--- a/tests/deep/files/test_code_dt_equations/construct_un_linked_disconnected_definition_einsum_out.py
+++ b/tests/deep/files/test_code_dt_equations/construct_un_linked_disconnected_definition_einsum_out.py
@@ -1,5 +1,5 @@
 
-def _order_2_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list):
+def _order_2_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_unlinked_path_list):
     """Calculate all uniquely un-linked disconnected terms generated from the wave operator ansatz.
     This means for order 5 we include terms such as (3, 2), (2, 2, 1)
     But not terms (5), (4, 1), (3, 1, 1), (2, 1, 1, 1), (1, 1, 1, 1, 1)
@@ -8,5 +8,5 @@ def _order_2_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args
     # unpack the `t_args` and 'dt_args'
     t_i, *unusedargs = t_args
     dt_i, *unusedargs = dt_args
-    # make an iterable out of the `opt_path_list`
-    optimized_einsum = iter(opt_path_list)
+    # make an iterable out of the `opt_unlinked_path_list`
+    optimized_einsum = iter(opt_unlinked_path_list)

--- a/tests/deep/files/test_code_dt_equations/write_dt_amplitude_strings_einsum_high_order_out.py
+++ b/tests/deep/files/test_code_dt_equations/write_dt_amplitude_strings_einsum_high_order_out.py
@@ -1,12 +1,10 @@
 
-def _calculate_order_5_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_epsilon, opt_path_list):
+def _calculate_order_5_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_epsilon, opt_linked_path_list, opt_unlinked_path_list):
     """Calculate the derivative of the 5 t-amplitude for use in the calculation of the residuals.
     Uses optimized summation paths generate using `contract_expression` from the `opt_einsum` library.
     """
     # unpack the `w_args`
     w_i, w_ij, w_ijk, w_ijkl, w_ijklm, *unusedargs = w_args
-    # make an iterable out of the `opt_path_list`
-    optimized_einsum = iter(opt_path_list)
     # Calculate the 5th order residual
     residual = residual_equations.calculate_order_5_residual(A, N, trunc, h_args, w_args)
     # subtract the epsilon term (which is R_0)
@@ -16,10 +14,10 @@ def _calculate_order_5_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_ar
     if ansatz.VECI:
         pass  # veci does not include any disconnected terms
     elif ansatz.VE_MIXED:
-        residual -= _order_5_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list)
+        residual -= _order_5_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_linked_path_list)
     elif ansatz.VECC:
-        residual -= _order_5_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list)
-        residual -= _order_5_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list)
+        residual -= _order_5_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_linked_path_list)
+        residual -= _order_5_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_unlinked_path_list)
 
     # Symmetrize the residual operator
     dt_ijklm = symmetrize_tensor(N, residual, order=5)

--- a/tests/deep/files/test_code_dt_equations/write_dt_amplitude_strings_einsum_out.py
+++ b/tests/deep/files/test_code_dt_equations/write_dt_amplitude_strings_einsum_out.py
@@ -1,12 +1,10 @@
 
-def _calculate_order_2_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_epsilon, opt_path_list):
+def _calculate_order_2_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_epsilon, opt_linked_path_list, opt_unlinked_path_list):
     """Calculate the derivative of the 2 t-amplitude for use in the calculation of the residuals.
     Uses optimized summation paths generate using `contract_expression` from the `opt_einsum` library.
     """
     # unpack the `w_args`
     w_i, w_ij, *unusedargs = w_args
-    # make an iterable out of the `opt_path_list`
-    optimized_einsum = iter(opt_path_list)
     # Calculate the 2nd order residual
     residual = residual_equations.calculate_order_2_residual(A, N, trunc, h_args, w_args)
     # subtract the epsilon term (which is R_0)
@@ -16,9 +14,9 @@ def _calculate_order_2_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_ar
     if ansatz.VECI:
         pass  # veci does not include any disconnected terms
     elif ansatz.VE_MIXED:
-        residual -= _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list)
+        residual -= _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_linked_path_list)
     elif ansatz.VECC:
-        residual -= _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list)
+        residual -= _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_linked_path_list)
         pass  # no un-linked disconnected terms for order < 4
 
     # Symmetrize the residual operator

--- a/tests/deep/files/test_code_dt_equations/write_linked_disconnected_strings_einsum_out.py
+++ b/tests/deep/files/test_code_dt_equations/write_linked_disconnected_strings_einsum_out.py
@@ -1,5 +1,5 @@
 
-def _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list):
+def _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_linked_path_list):
     """Calculate all uniquely linked disconnected terms generated from the wave operator ansatz.
     This means for order 5 we include terms such as (4, 1), (3, 1, 1), (2, 1, 1, 1)
     But not terms (5), (3, 2), (2, 2, 1), (1, 1, 1, 1, 1)
@@ -8,8 +8,8 @@ def _order_2_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, o
     # unpack the `t_args` and 'dt_args'
     t_i, *unusedargs = t_args
     dt_i, *unusedargs = dt_args
-    # make an iterable out of the `opt_path_list`
-    optimized_einsum = iter(opt_path_list)
+    # make an iterable out of the `opt_linked_path_list`
+    optimized_einsum = iter(opt_linked_path_list)
     # Creating the 2nd order return array
     linked_disconnected_terms = np.zeros((A, A, N, N), dtype=complex)
     # the (1, 1) term

--- a/tests/deep/files/test_code_dt_equations/write_master_dt_amplitude_function_einsum_out.py
+++ b/tests/deep/files/test_code_dt_equations/write_master_dt_amplitude_function_einsum_out.py
@@ -7,5 +7,12 @@ def solve_doubles_equations_optimized(A, N, ansatz, trunc, epsilon, h_args, t_ar
             "It appears that doubles is not true, this cannot be."
             "Something went terribly wrong!!!"
         )
-    dt_ij = _calculate_order_2_dt_amplitude_optimized(A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args, opt_path_list)
+
+    # unpack the opt_einsum path's
+    opt_epsilon_path_list, opt_linked_path_list, opt_unlinked_path_list = opt_path_list
+
+    dt_ij = _calculate_order_2_dt_amplitude_optimized(
+        A, N, ansatz, trunc, epsilon, h_args, t_args, dt_args, w_args,
+        opt_epsilon_path_list[1], opt_linked_path_list[1], opt_unlinked_path_list[1]
+    )
     return dt_ij

--- a/tests/deep/files/test_code_dt_equations/write_optimized_dt_amplitude_paths_function_out.py
+++ b/tests/deep/files/test_code_dt_equations/write_optimized_dt_amplitude_paths_function_out.py
@@ -1,8 +1,0 @@
-
-def compute_optimized_paths(A, N, truncation):
-    """Calculate optimized paths for the einsum calls up to `highest_order`."""
-
-    order_1_list, order_2_list, order_3_list = [], [], []
-    order_4_list, order_5_list, order_6_list = [], [], []
-
-    return [None]

--- a/tests/deep/files/test_code_dt_equations/write_optimized_epsilon_paths_function_out.py
+++ b/tests/deep/files/test_code_dt_equations/write_optimized_epsilon_paths_function_out.py
@@ -1,0 +1,22 @@
+
+def compute_optimized_epsilon_paths(A, N, truncation):
+    """Calculate optimized paths for the constant/epsilon einsum calls up to `highest_order`."""
+
+    epsilon_path_list = []
+
+    if truncation.singles:
+        epsilon_path_list.append(oe.contract_expression('aci,cb->abi', (A, A, N), (A, A)))
+
+    if truncation.doubles:
+        epsilon_path_list.append(oe.contract_expression('acij,cb->abij', (A, A, N, N), (A, A)))
+
+    if truncation.triples:
+        epsilon_path_list.append(oe.contract_expression('acijk,cb->abijk', (A, A, N, N, N), (A, A)))
+
+    if truncation.quadruples:
+        epsilon_path_list.append(oe.contract_expression('acijkl,cb->abijkl', (A, A, N, N, N, N), (A, A)))
+
+    if truncation.quintuples:
+        epsilon_path_list.append(oe.contract_expression('acijklm,cb->abijklm', (A, A, N, N, N, N, N), (A, A)))
+
+    return epsilon_path_list

--- a/tests/deep/files/test_code_dt_equations/write_optimized_linked_paths_function_out.py
+++ b/tests/deep/files/test_code_dt_equations/write_optimized_linked_paths_function_out.py
@@ -1,0 +1,108 @@
+
+def compute_optimized_linked_paths(A, N, truncation):
+    """Calculate optimized paths for the linked-disconnected einsum calls up to `highest_order`."""
+
+    order_1_list, order_2_list, order_3_list = [], [], []
+    order_4_list, order_5_list, order_6_list = [], [], []
+
+    if truncation.singles:
+        order_2_list.extend([
+            oe.contract_expression('aci, cbj->abij', (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cbj->abij', (A, A, N), (A, A, N)),
+        ])
+
+    if truncation.doubles:
+        order_3_list.extend([
+            oe.contract_expression('aci, cbjk->abijk', (A, A, N), (A, A, N, N)),
+            oe.contract_expression('aci, cbjk->abijk', (A, A, N), (A, A, N, N)),
+            oe.contract_expression('acij, cbk->abijk', (A, A, N, N), (A, A, N)),
+            oe.contract_expression('acij, cbk->abijk', (A, A, N, N), (A, A, N)),
+        ])
+
+    if truncation.singles:
+        order_3_list.extend([
+            oe.contract_expression('aci, cdj, dbk->abijk', (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dbk->abijk', (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dbk->abijk', (A, A, N), (A, A, N), (A, A, N)),
+        ])
+
+    if truncation.triples:
+        order_4_list.extend([
+            oe.contract_expression('aci, cbjkl->abijkl', (A, A, N), (A, A, N, N, N)),
+            oe.contract_expression('aci, cbjkl->abijkl', (A, A, N), (A, A, N, N, N)),
+            oe.contract_expression('acijk, cbl->abijkl', (A, A, N, N, N), (A, A, N)),
+            oe.contract_expression('acijk, cbl->abijkl', (A, A, N, N, N), (A, A, N)),
+        ])
+
+    if truncation.doubles:
+        order_4_list.extend([
+            oe.contract_expression('aci, cdj, dbkl->abijkl', (A, A, N), (A, A, N), (A, A, N, N)),
+            oe.contract_expression('aci, cdj, dbkl->abijkl', (A, A, N), (A, A, N), (A, A, N, N)),
+            oe.contract_expression('aci, cdj, dbkl->abijkl', (A, A, N), (A, A, N), (A, A, N, N)),
+            oe.contract_expression('aci, cdjk, dbl->abijkl', (A, A, N), (A, A, N, N), (A, A, N)),
+            oe.contract_expression('aci, cdjk, dbl->abijkl', (A, A, N), (A, A, N, N), (A, A, N)),
+            oe.contract_expression('aci, cdjk, dbl->abijkl', (A, A, N), (A, A, N, N), (A, A, N)),
+            oe.contract_expression('acij, cdk, dbl->abijkl', (A, A, N, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('acij, cdk, dbl->abijkl', (A, A, N, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('acij, cdk, dbl->abijkl', (A, A, N, N), (A, A, N), (A, A, N)),
+        ])
+
+    if truncation.singles:
+        order_4_list.extend([
+            oe.contract_expression('aci, cdj, dek, ebl->abijkl', (A, A, N), (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dek, ebl->abijkl', (A, A, N), (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dek, ebl->abijkl', (A, A, N), (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dek, ebl->abijkl', (A, A, N), (A, A, N), (A, A, N), (A, A, N)),
+        ])
+
+    if truncation.quadruples:
+        order_5_list.extend([
+            oe.contract_expression('aci, cbjklm->abijklm', (A, A, N), (A, A, N, N, N, N)),
+            oe.contract_expression('aci, cbjklm->abijklm', (A, A, N), (A, A, N, N, N, N)),
+            oe.contract_expression('acijkl, cbm->abijklm', (A, A, N, N, N, N), (A, A, N)),
+            oe.contract_expression('acijkl, cbm->abijklm', (A, A, N, N, N, N), (A, A, N)),
+        ])
+
+    if truncation.triples:
+        order_5_list.extend([
+            oe.contract_expression('aci, cdj, dbklm->abijklm', (A, A, N), (A, A, N), (A, A, N, N, N)),
+            oe.contract_expression('aci, cdj, dbklm->abijklm', (A, A, N), (A, A, N), (A, A, N, N, N)),
+            oe.contract_expression('aci, cdj, dbklm->abijklm', (A, A, N), (A, A, N), (A, A, N, N, N)),
+            oe.contract_expression('aci, cdjkl, dbm->abijklm', (A, A, N), (A, A, N, N, N), (A, A, N)),
+            oe.contract_expression('aci, cdjkl, dbm->abijklm', (A, A, N), (A, A, N, N, N), (A, A, N)),
+            oe.contract_expression('aci, cdjkl, dbm->abijklm', (A, A, N), (A, A, N, N, N), (A, A, N)),
+            oe.contract_expression('acijk, cdl, dbm->abijklm', (A, A, N, N, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('acijk, cdl, dbm->abijklm', (A, A, N, N, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('acijk, cdl, dbm->abijklm', (A, A, N, N, N), (A, A, N), (A, A, N)),
+        ])
+
+    if truncation.doubles:
+        order_5_list.extend([
+            oe.contract_expression('aci, cdj, dek, eblm->abijklm', (A, A, N), (A, A, N), (A, A, N), (A, A, N, N)),
+            oe.contract_expression('aci, cdj, dek, eblm->abijklm', (A, A, N), (A, A, N), (A, A, N), (A, A, N, N)),
+            oe.contract_expression('aci, cdj, dek, eblm->abijklm', (A, A, N), (A, A, N), (A, A, N), (A, A, N, N)),
+            oe.contract_expression('aci, cdj, dek, eblm->abijklm', (A, A, N), (A, A, N), (A, A, N), (A, A, N, N)),
+            oe.contract_expression('aci, cdj, dekl, ebm->abijklm', (A, A, N), (A, A, N), (A, A, N, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dekl, ebm->abijklm', (A, A, N), (A, A, N), (A, A, N, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dekl, ebm->abijklm', (A, A, N), (A, A, N), (A, A, N, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dekl, ebm->abijklm', (A, A, N), (A, A, N), (A, A, N, N), (A, A, N)),
+            oe.contract_expression('aci, cdjk, del, ebm->abijklm', (A, A, N), (A, A, N, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdjk, del, ebm->abijklm', (A, A, N), (A, A, N, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdjk, del, ebm->abijklm', (A, A, N), (A, A, N, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdjk, del, ebm->abijklm', (A, A, N), (A, A, N, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('acij, cdk, del, ebm->abijklm', (A, A, N, N), (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('acij, cdk, del, ebm->abijklm', (A, A, N, N), (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('acij, cdk, del, ebm->abijklm', (A, A, N, N), (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('acij, cdk, del, ebm->abijklm', (A, A, N, N), (A, A, N), (A, A, N), (A, A, N)),
+        ])
+
+    if truncation.singles:
+        order_5_list.extend([
+            oe.contract_expression('aci, cdj, dek, efl, fbm->abijklm', (A, A, N), (A, A, N), (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dek, efl, fbm->abijklm', (A, A, N), (A, A, N), (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dek, efl, fbm->abijklm', (A, A, N), (A, A, N), (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dek, efl, fbm->abijklm', (A, A, N), (A, A, N), (A, A, N), (A, A, N), (A, A, N)),
+            oe.contract_expression('aci, cdj, dek, efl, fbm->abijklm', (A, A, N), (A, A, N), (A, A, N), (A, A, N), (A, A, N)),
+        ])
+
+    return [order_1_list, order_2_list, order_3_list, order_4_list, order_5_list]

--- a/tests/deep/files/test_code_dt_equations/write_optimized_unlinked_paths_function_out.py
+++ b/tests/deep/files/test_code_dt_equations/write_optimized_unlinked_paths_function_out.py
@@ -1,0 +1,39 @@
+
+def compute_optimized_unlinked_paths(A, N, truncation):
+    """Calculate optimized paths for the unlinked-disconnected einsum calls up to `highest_order`."""
+
+    order_1_list, order_2_list, order_3_list = [], [], []
+    order_4_list, order_5_list, order_6_list = [], [], []
+
+    if not truncation.doubles:
+        log.warning('Did not calculate optimized unlinked paths of the dt amplitudes')
+        return [[], [], [], [], [], []]
+
+    if truncation.doubles:
+        order_4_list.extend([
+            oe.contract_expression('acij, cbkl->abijkl', (A, A, N, N), (A, A, N, N)),
+            oe.contract_expression('acij, cbkl->abijkl', (A, A, N, N), (A, A, N, N)),
+        ])
+
+    if truncation.triples:
+        order_5_list.extend([
+            oe.contract_expression('acij, cbklm->abijklm', (A, A, N, N), (A, A, N, N, N)),
+            oe.contract_expression('acij, cbklm->abijklm', (A, A, N, N), (A, A, N, N, N)),
+            oe.contract_expression('acijk, cblm->abijklm', (A, A, N, N, N), (A, A, N, N)),
+            oe.contract_expression('acijk, cblm->abijklm', (A, A, N, N, N), (A, A, N, N)),
+        ])
+
+    if truncation.doubles:
+        order_5_list.extend([
+            oe.contract_expression('aci, cdjk, dblm->abijklm', (A, A, N), (A, A, N, N), (A, A, N, N)),
+            oe.contract_expression('aci, cdjk, dblm->abijklm', (A, A, N), (A, A, N, N), (A, A, N, N)),
+            oe.contract_expression('aci, cdjk, dblm->abijklm', (A, A, N), (A, A, N, N), (A, A, N, N)),
+            oe.contract_expression('acij, cdk, dblm->abijklm', (A, A, N, N), (A, A, N), (A, A, N, N)),
+            oe.contract_expression('acij, cdk, dblm->abijklm', (A, A, N, N), (A, A, N), (A, A, N, N)),
+            oe.contract_expression('acij, cdk, dblm->abijklm', (A, A, N, N), (A, A, N), (A, A, N, N)),
+            oe.contract_expression('acij, cdkl, dbm->abijklm', (A, A, N, N), (A, A, N, N), (A, A, N)),
+            oe.contract_expression('acij, cdkl, dbm->abijklm', (A, A, N, N), (A, A, N, N), (A, A, N)),
+            oe.contract_expression('acij, cdkl, dbm->abijklm', (A, A, N, N), (A, A, N, N), (A, A, N)),
+        ])
+
+    return [order_1_list, order_2_list, order_3_list, order_4_list, order_5_list]

--- a/tests/deep/files/test_code_dt_equations/write_un_linked_disconnected_strings_high_order_einsum_out.py
+++ b/tests/deep/files/test_code_dt_equations/write_un_linked_disconnected_strings_high_order_einsum_out.py
@@ -1,5 +1,5 @@
 
-def _order_5_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_path_list):
+def _order_5_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args, opt_unlinked_path_list):
     """Calculate all uniquely un-linked disconnected terms generated from the wave operator ansatz.
     This means for order 5 we include terms such as (3, 2), (2, 2, 1)
     But not terms (5), (4, 1), (3, 1, 1), (2, 1, 1, 1), (1, 1, 1, 1, 1)
@@ -8,8 +8,8 @@ def _order_5_un_linked_disconnected_terms_optimized(A, N, trunc, t_args, dt_args
     # unpack the `t_args` and 'dt_args'
     t_i, t_ij, t_ijk, t_ijkl, *unusedargs = t_args
     dt_i, dt_ij, dt_ijk, dt_ijkl, *unusedargs = dt_args
-    # make an iterable out of the `opt_path_list`
-    optimized_einsum = iter(opt_path_list)
+    # make an iterable out of the `opt_unlinked_path_list`
+    optimized_einsum = iter(opt_unlinked_path_list)
     # Creating the 5th order return array
     un_linked_disconnected_terms = np.zeros((A, A, N, N, N, N, N), dtype=complex)
     # the (3, 2) term

--- a/tests/deep/test_code_dt_equations.py
+++ b/tests/deep/test_code_dt_equations.py
@@ -427,17 +427,54 @@ class Test_write_master_dt_amplitude_function:
 
 class Test_write_optimized_dt_amplitude_paths_function:
 
-    def test_basic(self):
-        """basic test"""
+
+    def test_epsilon_paths(self):
+        """epsilon test"""
 
         # input data
-        max_order = 2
+        max_order = 5
 
         # run function
-        function_output = cdt._write_optimized_dt_amplitude_paths_function(max_order)
+        function_output = cdt._write_optimized_epsilon_paths_function(max_order)
 
         # open file
-        func_name = "write_optimized_dt_amplitude_paths_function_out.py"
+        func_name = "write_optimized_epsilon_paths_function_out.py"
+        file_name = join(root_dir, classtest, func_name)
+        with open(file_name, 'r') as fp:
+            expected_result = fp.read()
+
+        assert function_output == expected_result
+
+
+    def test_linked_paths(self):
+        """linked test"""
+
+        # input data
+        max_order = 5
+
+        # run function
+        function_output = cdt._write_optimized_linked_paths_function(max_order)
+
+        # open file
+        func_name = "write_optimized_linked_paths_function_out.py"
+        file_name = join(root_dir, classtest, func_name)
+        with open(file_name, 'r') as fp:
+            expected_result = fp.read()
+
+        assert function_output == expected_result
+
+
+    def test_unlinked_paths(self):
+        """unlinked test"""
+
+        # input data
+        max_order = 5
+
+        # run function
+        function_output = cdt._write_optimized_unlinked_paths_function(max_order)
+
+        # open file
+        func_name = "write_optimized_unlinked_paths_function_out.py"
         file_name = join(root_dir, classtest, func_name)
         with open(file_name, 'r') as fp:
             expected_result = fp.read()


### PR DESCRIPTION
Need to split the paths into three groups:
- epsilon 
 - linked disconnected
 - un-linked disconnected

Also need to write additional functions for each group to generate
the appropriate `opt_einsum` paths